### PR TITLE
chore: BPMN consolidation cleanup — docs, CI, operating model

### DIFF
--- a/.github/prompts/codex_pr_review.md
+++ b/.github/prompts/codex_pr_review.md
@@ -1,0 +1,77 @@
+You are Codex acting as the Planning + Review Agent for this repository.
+
+Follow `OPERATING.MD` exactly for review behavior:
+- prioritize findings over summaries
+- review against acceptance criteria, correctness, regression risk, code quality, security, and test completeness
+- output `APPROVE` or `REQUEST CHANGES`
+- keep scope limited to the PR and linked issue
+- do not suggest unrelated refactors
+
+Repository instructions:
+- `OPERATING.MD` is the source of truth for workflow and review expectations
+- GitHub issue is the task definition
+- Approved plan is the implementation boundary
+- Review should identify bugs, regressions, missing tests, scope drift, broken docs/links, and mismatches with the plan
+
+You are reviewing this pull request.
+
+## Inputs
+
+### Issue
+{{ISSUE_TITLE}}
+
+{{ISSUE_BODY}}
+
+### Approved Plan
+{{APPROVED_PLAN}}
+
+### PR Metadata
+- PR: {{PR_NUMBER}}
+- Title: {{PR_TITLE}}
+- Base: {{BASE_BRANCH}}
+- Head: {{HEAD_BRANCH}}
+
+### PR Summary
+{{PR_SUMMARY}}
+
+### Changed Files
+{{CHANGED_FILES}}
+
+### Diff
+```diff
+{{PR_DIFF}}
+```
+
+## Review Tasks
+
+1. Check whether the PR satisfies the issue objective and acceptance criteria.
+2. Identify correctness issues, regressions, broken links/docs, misleading documentation, missing validation, and scope creep.
+3. Verify that tests are appropriate for the change.
+4. Call out any assumptions or unclear areas.
+5. Give a clear final verdict.
+
+## Required Output Format
+
+### Verdict
+`APPROVE` or `REQUEST CHANGES`
+
+### Criteria Check
+- Acceptance criteria met or not met, with short reasons
+
+### Issues Found
+- List findings ordered by severity
+- Include file paths and line references when possible
+- If no findings exist, say `No findings.`
+
+### Missing Validation
+- List missing or insufficient tests/checks
+- If validation is adequate, say `None.`
+
+### Recommended Next Step
+- One short concrete next action
+
+Important:
+- Findings must come before any general summary.
+- Be concise and specific.
+- Do not praise unnecessarily.
+- If there are no findings, say so explicitly and still mention any residual risks.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,43 @@
+## What changed
+
+<!-- Summarize the implementation in 2-5 bullets. -->
+
+## Why
+
+- Issue: #<issue-number>
+- Objective: <!-- Short statement of the problem being solved -->
+
+## Approved Plan
+
+<!-- Paste the approved Codex plan here. -->
+
+## Scope Check
+
+- [ ] Change stays within the approved plan
+- [ ] No unrelated refactors
+- [ ] Tests updated only where needed
+
+## Files changed
+
+<!-- e.g. path/to/file — reason -->
+
+- path/to/file — reason
+
+## Validation
+
+- Tests:
+- Lint/type-check:
+- Manual verification:
+
+## Acceptance Criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Remaining Risks
+
+<!-- List anything still uncertain. -->
+
+## Follow-ups
+
+<!-- List any separate issues or operational steps that should happen later. -->

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -17,8 +17,10 @@ jobs:
       OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-5.2' }}
     steps:
       - name: Check required secret
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          if [ -z "${{ secrets.OPENAI_API_KEY }}" ]; then
+          if [ -z "$OPENAI_API_KEY" ]; then
             echo "OPENAI_API_KEY secret is required for Codex PR review." >&2
             exit 1
           fi
@@ -147,34 +149,61 @@ jobs:
           import os
           import pathlib
           import urllib.request
+          import urllib.error
+
+          def extract_responses_api_text(resp: dict) -> str:
+              """Collect assistant text from raw /v1/responses JSON (no SDK output_text helper)."""
+              # Some proxies or future API versions may expose a flat field
+              flat = resp.get("output_text")
+              if isinstance(flat, str) and flat.strip():
+                  return flat.strip()
+              parts: list[str] = []
+              for item in resp.get("output") or []:
+                  if not isinstance(item, dict):
+                      continue
+                  for block in item.get("content") or []:
+                      if not isinstance(block, dict):
+                          continue
+                      if block.get("type") in ("output_text", "text"):
+                          t = block.get("text")
+                          if isinstance(t, str) and t:
+                              parts.append(t)
+              return "\n".join(parts).strip()
 
           prompt = pathlib.Path("codex_review_prompt.txt").read_text()
           payload = {
-            "model": os.environ.get("OPENAI_MODEL", "gpt-5.2"),
-            "input": prompt,
+              "model": os.environ.get("OPENAI_MODEL", "gpt-5.2"),
+              "input": prompt,
           }
 
           request = urllib.request.Request(
-            "https://api.openai.com/v1/responses",
-            data=json.dumps(payload).encode("utf-8"),
-            headers={
-              "Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}",
-              "Content-Type": "application/json",
-            },
-            method="POST",
+              "https://api.openai.com/v1/responses",
+              data=json.dumps(payload).encode("utf-8"),
+              headers={
+                  "Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}",
+                  "Content-Type": "application/json",
+              },
+              method="POST",
           )
 
-          with urllib.request.urlopen(request) as response:
-            body = json.loads(response.read().decode("utf-8"))
+          try:
+              with urllib.request.urlopen(request) as response:
+                  body = json.loads(response.read().decode("utf-8"))
+          except urllib.error.HTTPError as e:
+              err = e.read().decode("utf-8", errors="replace")
+              raise SystemExit(f"OpenAI API HTTP {e.code}: {err}") from e
 
-          output_text = body.get("output_text", "").strip()
+          output_text = extract_responses_api_text(body)
           if not output_text:
-            raise SystemExit("OpenAI response did not contain output_text.")
+              raise SystemExit(
+                  "OpenAI response contained no extractable text "
+                  "(expected output[].content[] with type output_text/text)."
+              )
 
           pathlib.Path("codex_review.md").write_text(
-            "<!-- codex-pr-review -->\n"
-            "## Codex Review\n\n"
-            f"{output_text}\n"
+              "<!-- codex-pr-review -->\n"
+              "## Codex Review\n\n"
+              f"{output_text}\n"
           )
           PY
 

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -1,0 +1,222 @@
+name: Codex PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: write
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    env:
+      OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-5.2' }}
+    steps:
+      - name: Check required secret
+        run: |
+          if [ -z "${{ secrets.OPENAI_API_KEY }}" ]; then
+            echo "OPENAI_API_KEY secret is required for Codex PR review." >&2
+            exit 1
+          fi
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Collect PR metadata and linked issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const pr = context.payload.pull_request;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner,
+                repo,
+                pull_number: pr.number,
+                per_page: 100,
+              }
+            );
+
+            const prContext = {
+              number: pr.number,
+              title: pr.title,
+              body: pr.body || "",
+              base: pr.base.ref,
+              head: pr.head.ref,
+              changed_files: files.map((f) => f.filename),
+            };
+            fs.writeFileSync("pr_context.json", JSON.stringify(prContext, null, 2));
+
+            const body = pr.body || "";
+            const issueMatch =
+              body.match(/(?:^|\n)-\s*Issue:\s*#(\d+)\b/i) ||
+              body.match(/(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/i);
+
+            let issueContext = {
+              number: null,
+              title: "No linked issue found.",
+              body: "PR body did not include a parseable issue reference.",
+            };
+
+            if (issueMatch) {
+              const issue_number = Number(issueMatch[1]);
+              const issue = await github.rest.issues.get({
+                owner,
+                repo,
+                issue_number,
+              });
+              issueContext = {
+                number: issue_number,
+                title: issue.data.title,
+                body: issue.data.body || "",
+              };
+            }
+
+            fs.writeFileSync("issue_context.json", JSON.stringify(issueContext, null, 2));
+
+      - name: Build diff snapshot
+        run: |
+          git fetch origin "${{ github.event.pull_request.base.ref }}" --depth=1
+          git diff --unified=2 "origin/${{ github.event.pull_request.base.ref }}...HEAD" > pr.diff
+
+      - name: Build Codex review prompt
+        run: |
+          python - <<'PY'
+          import json
+          import pathlib
+          import re
+
+          root = pathlib.Path(".")
+          template = (root / ".github" / "prompts" / "codex_pr_review.md").read_text()
+          pr = json.loads((root / "pr_context.json").read_text())
+          issue = json.loads((root / "issue_context.json").read_text())
+          diff = (root / "pr.diff").read_text()
+
+          def extract_section(markdown: str, heading: str) -> str:
+            pattern = re.compile(
+                rf"^##\s+{re.escape(heading)}\s*$\n(.*?)(?=^##\s+|\Z)",
+                re.MULTILINE | re.DOTALL,
+            )
+            match = pattern.search(markdown or "")
+            return match.group(1).strip() if match else ""
+
+          approved_plan = extract_section(pr.get("body", ""), "Approved Plan")
+          pr_summary = extract_section(pr.get("body", ""), "What changed") or (pr.get("body", "")[:4000])
+          changed_files = "\n".join(f"- {path}" for path in pr.get("changed_files", [])) or "- None"
+
+          max_diff_chars = 120000
+          if len(diff) > max_diff_chars:
+            diff = diff[:max_diff_chars] + "\n\n[diff truncated for review]"
+
+          replacements = {
+            "{{ISSUE_TITLE}}": issue.get("title", ""),
+            "{{ISSUE_BODY}}": issue.get("body", ""),
+            "{{APPROVED_PLAN}}": approved_plan or "No approved plan section found in the PR body.",
+            "{{PR_NUMBER}}": str(pr.get("number", "")),
+            "{{PR_TITLE}}": pr.get("title", ""),
+            "{{BASE_BRANCH}}": pr.get("base", ""),
+            "{{HEAD_BRANCH}}": pr.get("head", ""),
+            "{{PR_SUMMARY}}": pr_summary or "No PR summary provided.",
+            "{{CHANGED_FILES}}": changed_files,
+            "{{PR_DIFF}}": diff,
+          }
+
+          prompt = template
+          for key, value in replacements.items():
+            prompt = prompt.replace(key, value)
+
+          (root / "codex_review_prompt.txt").write_text(prompt)
+          PY
+
+      - name: Request Codex review from OpenAI
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import pathlib
+          import urllib.request
+
+          prompt = pathlib.Path("codex_review_prompt.txt").read_text()
+          payload = {
+            "model": os.environ.get("OPENAI_MODEL", "gpt-5.2"),
+            "input": prompt,
+          }
+
+          request = urllib.request.Request(
+            "https://api.openai.com/v1/responses",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={
+              "Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}",
+              "Content-Type": "application/json",
+            },
+            method="POST",
+          )
+
+          with urllib.request.urlopen(request) as response:
+            body = json.loads(response.read().decode("utf-8"))
+
+          output_text = body.get("output_text", "").strip()
+          if not output_text:
+            raise SystemExit("OpenAI response did not contain output_text.")
+
+          pathlib.Path("codex_review.md").write_text(
+            "<!-- codex-pr-review -->\n"
+            "## Codex Review\n\n"
+            f"{output_text}\n"
+          )
+          PY
+
+      - name: Create or update PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const body = fs.readFileSync("codex_review.md", "utf8");
+            const marker = "<!-- codex-pr-review -->";
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.pull_request.number;
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner,
+                repo,
+                issue_number: pull_number,
+                per_page: 100,
+              }
+            );
+
+            const existing = comments.find(
+              (comment) =>
+                comment.user.type === "Bot" &&
+                comment.body &&
+                comment.body.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pull_number,
+                body,
+              });
+            }

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -152,23 +152,38 @@ jobs:
           import urllib.error
 
           def extract_responses_api_text(resp: dict) -> str:
-              """Collect assistant text from raw /v1/responses JSON (no SDK output_text helper)."""
-              # Some proxies or future API versions may expose a flat field
-              flat = resp.get("output_text")
-              if isinstance(flat, str) and flat.strip():
-                  return flat.strip()
+              """Aggregate assistant-visible text from raw /v1/responses JSON.
+
+              The wire JSON has no top-level ``output_text``; that field exists only as
+              a convenience property on SDK objects (see OpenAI Python ``Response.output_text``).
+              Match SDK behavior: only ``output`` items with ``type == "message"``, and
+              ``content`` blocks of type ``output_text`` (plus ``refusal`` / legacy ``text``).
+              """
+              err = resp.get("error")
+              if isinstance(err, dict) and err.get("message"):
+                  raise SystemExit(f"OpenAI API error: {err.get('message')}")
+
               parts: list[str] = []
               for item in resp.get("output") or []:
-                  if not isinstance(item, dict):
+                  if not isinstance(item, dict) or item.get("type") != "message":
                       continue
                   for block in item.get("content") or []:
                       if not isinstance(block, dict):
                           continue
-                      if block.get("type") in ("output_text", "text"):
+                      btype = block.get("type")
+                      if btype == "output_text":
                           t = block.get("text")
                           if isinstance(t, str) and t:
                               parts.append(t)
-              return "\n".join(parts).strip()
+                      elif btype == "refusal":
+                          r = block.get("refusal")
+                          if isinstance(r, str) and r:
+                              parts.append(r)
+                      elif btype == "text":
+                          t = block.get("text")
+                          if isinstance(t, str) and t:
+                              parts.append(t)
+              return "".join(parts).strip()
 
           prompt = pathlib.Path("codex_review_prompt.txt").read_text()
           payload = {
@@ -197,7 +212,8 @@ jobs:
           if not output_text:
               raise SystemExit(
                   "OpenAI response contained no extractable text "
-                  "(expected output[].content[] with type output_text/text)."
+                  "(expected output[] items with type 'message' and "
+                  "content[] blocks of type output_text, refusal, or text)."
               )
 
           pathlib.Path("codex_review.md").write_text(

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -16,21 +16,28 @@ jobs:
     env:
       OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-5.2' }}
     steps:
-      - name: Check required secret
+      # Succeed without running review when the secret is unset (fork PRs, or repo not
+      # configured yet) so a required "Codex PR Review" check does not block merges.
+      - name: Gate (OPENAI_API_KEY)
+        id: codex_gate
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          if [ -z "$OPENAI_API_KEY" ]; then
-            echo "OPENAI_API_KEY secret is required for Codex PR review." >&2
-            exit 1
+          if [ -n "$OPENAI_API_KEY" ]; then
+            echo "run_review=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_review=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Codex PR review skipped: add the OPENAI_API_KEY repository secret to enable automated reviews."
           fi
 
       - name: Check out repository
+        if: steps.codex_gate.outputs.run_review == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Collect PR metadata and linked issue
+        if: steps.codex_gate.outputs.run_review == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -87,11 +94,13 @@ jobs:
             fs.writeFileSync("issue_context.json", JSON.stringify(issueContext, null, 2));
 
       - name: Build diff snapshot
+        if: steps.codex_gate.outputs.run_review == 'true'
         run: |
           git fetch origin "${{ github.event.pull_request.base.ref }}" --depth=1
           git diff --unified=2 "origin/${{ github.event.pull_request.base.ref }}...HEAD" > pr.diff
 
       - name: Build Codex review prompt
+        if: steps.codex_gate.outputs.run_review == 'true'
         run: |
           python - <<'PY'
           import json
@@ -120,27 +129,39 @@ jobs:
           if len(diff) > max_diff_chars:
             diff = diff[:max_diff_chars] + "\n\n[diff truncated for review]"
 
-          replacements = {
-            "{{ISSUE_TITLE}}": issue.get("title", ""),
-            "{{ISSUE_BODY}}": issue.get("body", ""),
-            "{{APPROVED_PLAN}}": approved_plan or "No approved plan section found in the PR body.",
-            "{{PR_NUMBER}}": str(pr.get("number", "")),
-            "{{PR_TITLE}}": pr.get("title", ""),
-            "{{BASE_BRANCH}}": pr.get("base", ""),
-            "{{HEAD_BRANCH}}": pr.get("head", ""),
-            "{{PR_SUMMARY}}": pr_summary or "No PR summary provided.",
-            "{{CHANGED_FILES}}": changed_files,
-            "{{PR_DIFF}}": diff,
+          # Single-pass substitution: sequential str.replace() would re-expand
+          # placeholder-shaped text inside user-controlled fields (e.g. {{PR_DIFF}} in issue body).
+          values = {
+            "ISSUE_TITLE": issue.get("title", ""),
+            "ISSUE_BODY": issue.get("body", ""),
+            "APPROVED_PLAN": approved_plan or "No approved plan section found in the PR body.",
+            "PR_NUMBER": str(pr.get("number", "")),
+            "PR_TITLE": pr.get("title", ""),
+            "BASE_BRANCH": pr.get("base", ""),
+            "HEAD_BRANCH": pr.get("head", ""),
+            "PR_SUMMARY": pr_summary or "No PR summary provided.",
+            "CHANGED_FILES": changed_files,
+            "PR_DIFF": diff,
           }
+          placeholder_re = re.compile(r"\{\{([A-Z][A-Z0-9_]*)\}\}")
 
-          prompt = template
-          for key, value in replacements.items():
-            prompt = prompt.replace(key, value)
+          def substitute_template(t: str) -> str:
+            def repl(m):
+              name = m.group(1)
+              if name not in values:
+                return m.group(0)
+              return values[name]
+
+            return placeholder_re.sub(repl, t)
+
+          prompt = substitute_template(template)
 
           (root / "codex_review_prompt.txt").write_text(prompt)
           PY
 
       - name: Request Codex review from OpenAI
+        if: steps.codex_gate.outputs.run_review == 'true'
+        id: codex_review
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
@@ -148,6 +169,7 @@ jobs:
           import json
           import os
           import pathlib
+          import sys
           import urllib.request
           import urllib.error
 
@@ -205,25 +227,65 @@ jobs:
               with urllib.request.urlopen(request) as response:
                   body = json.loads(response.read().decode("utf-8"))
           except urllib.error.HTTPError as e:
-              err = e.read().decode("utf-8", errors="replace")
-              raise SystemExit(f"OpenAI API HTTP {e.code}: {err}") from e
+              raw = e.read().decode("utf-8", errors="replace")
+              message = f"OpenAI API HTTP {e.code}"
+              try:
+                  err = json.loads(raw)
+                  api_error = err.get("error") or {}
+                  detail = api_error.get("message")
+                  code = api_error.get("code")
+                  if detail:
+                      message = f"{message}: {detail}"
+                  if code:
+                      message = f"{message} (code: {code})"
+              except json.JSONDecodeError:
+                  if raw.strip():
+                      message = f"{message}: {raw.strip()}"
+
+              pathlib.Path("codex_review.md").write_text(
+                  "<!-- codex-pr-review -->\n"
+                  "## Codex Review\n\n"
+                  "Review was not generated because the OpenAI API request failed.\n\n"
+                  f"- Error: `{message}`\n"
+                  "- Action: check API billing/quota, secret configuration, and retry the workflow.\n"
+              )
+              pathlib.Path("codex_review_status.txt").write_text("degraded\n")
+              print(message, file=sys.stderr)
+              raise SystemExit(0) from e
+          except urllib.error.URLError as e:
+              message = f"OpenAI API connection error: {e.reason}"
+              pathlib.Path("codex_review.md").write_text(
+                  "<!-- codex-pr-review -->\n"
+                  "## Codex Review\n\n"
+                  "Review was not generated because the OpenAI API could not be reached.\n\n"
+                  f"- Error: `{message}`\n"
+                  "- Action: retry the workflow after confirming outbound network access and API availability.\n"
+              )
+              pathlib.Path("codex_review_status.txt").write_text("degraded\n")
+              print(message, file=sys.stderr)
+              raise SystemExit(0) from e
 
           output_text = extract_responses_api_text(body)
           if not output_text:
-              raise SystemExit(
-                  "OpenAI response contained no extractable text "
-                  "(expected output[] items with type 'message' and "
-                  "content[] blocks of type output_text, refusal, or text)."
+              pathlib.Path("codex_review.md").write_text(
+                  "<!-- codex-pr-review -->\n"
+                  "## Codex Review\n\n"
+                  "Review was not generated because the OpenAI response did not contain extractable review text.\n\n"
+                  "- Action: inspect the workflow logs and retry.\n"
               )
+              pathlib.Path("codex_review_status.txt").write_text("degraded\n")
+              raise SystemExit(0)
 
           pathlib.Path("codex_review.md").write_text(
               "<!-- codex-pr-review -->\n"
               "## Codex Review\n\n"
               f"{output_text}\n"
           )
+          pathlib.Path("codex_review_status.txt").write_text("ok\n")
           PY
 
       - name: Create or update PR comment
+        if: steps.codex_gate.outputs.run_review == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -245,7 +307,7 @@ jobs:
 
             const existing = comments.find(
               (comment) =>
-                comment.user.type === "Bot" &&
+                comment.user?.type === "Bot" &&
                 comment.body &&
                 comment.body.includes(marker)
             );
@@ -265,3 +327,10 @@ jobs:
                 body,
               });
             }
+
+      - name: Surface degraded review state
+        if: steps.codex_gate.outputs.run_review == 'true'
+        run: |
+          if [ -f codex_review_status.txt ] && [ "$(cat codex_review_status.txt)" = "degraded" ]; then
+            echo "Codex PR review completed in degraded mode; see PR comment for details."
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+This repository follows the workflow in **[OPERATING.MD](OPERATING.MD)**. Read it before opening a PR.
+
+## GitHub issue first
+
+- Define work in a **GitHub Issue** with clear **acceptance criteria** before implementation.
+- Branch names: `feature/<issue-number>-short-name`, `fix/<issue-number>-short-name`, or `chore/<issue-number>-short-name` (see OPERATING.MD §9).
+- The PR should **link the issue** (e.g. `Fixes #123` in the description).
+
+## Plan → implement → review
+
+1. **Plan** — Agree on an implementation plan (scope, files, tests, risks) before coding; do not expand beyond the issue.
+2. **Implement** — Small, focused changes; follow existing patterns; add or update tests for behavior changes.
+3. **Review** — PR is the review boundary; address feedback before merge.
+
+## Commits
+
+Use structured prefixes when possible (OPERATING.MD §10):
+
+- `feat:` — new functionality  
+- `fix:` — bug fix  
+- `test:` — tests only  
+- `chore:` — tooling, docs, non-functional  
+
+## Validation
+
+Run tests and checks relevant to your change. Example for Django/agent work:
+
+```bash
+cd agent_ui && ../venv/bin/python manage.py test <target_tests> -q
+```
+
+## PR description
+
+Opening a PR pre-fills **[.github/pull_request_template.md](.github/pull_request_template.md)** — complete all sections.

--- a/OPERATING.MD
+++ b/OPERATING.MD
@@ -1,0 +1,292 @@
+# OPERATING.md
+
+## Agentic Development Workflow (Codex + Cursor + GitHub)
+
+---
+
+# 1. Purpose
+
+This document defines the **standard operating procedure** for implementing features and fixes using:
+
+* **Codex** → Planning + Review Agent
+* **Cursor** → Implementation Agent
+* **GitHub** → System of record (issues, code, PRs)
+
+Goal:
+
+> Deliver small, correct, testable changes with a clear plan → implementation → review loop.
+
+---
+
+# 2. Core Principles
+
+1. **Plan before code**
+2. **Small, reviewable changes**
+3. **Strict scope control**
+4. **Test everything that changes**
+5. **GitHub is the source of truth**
+6. **Agents have clearly separated responsibilities**
+
+---
+
+# 3. Roles & Responsibilities
+
+## Codex (Planning + Review Agent)
+
+Responsibilities:
+
+* Analyze repository structure
+* Produce implementation plans
+* Identify risks and dependencies
+* Review completed work
+* Validate against acceptance criteria
+
+Must NOT:
+
+* Implement code before plan approval
+* Expand scope beyond issue
+
+---
+
+## Cursor (Implementation Agent)
+
+Responsibilities:
+
+* Execute approved plans
+* Follow repo conventions
+* Write minimal, correct code
+* Add/update tests
+* Run validation (lint, tests, type checks)
+
+Must NOT:
+
+* Change architecture without explicit instruction
+* Modify unrelated files
+* Expand scope
+
+---
+
+## GitHub (Control Plane)
+
+Used for:
+
+* Issues (task definition)
+* Branches (work isolation)
+* Pull Requests (review boundary)
+* History (audit trail)
+
+---
+
+# 4. Workflow
+
+## Phase 1 — Plan
+
+1. Create GitHub Issue
+
+2. Ask Codex:
+
+   “Analyze repo and produce implementation plan. Do not code.”
+
+3. Review and refine plan
+
+4. Confirm acceptance criteria
+
+---
+
+## Phase 2 — Implement
+
+1. Create branch:
+   feature/<issue-number>-short-name
+
+2. Give Cursor:
+
+   * GitHub Issue
+   * Approved plan
+
+3. Cursor:
+
+   * Implements step-by-step
+   * Keeps changes minimal
+   * Adds tests
+   * Runs validation
+
+---
+
+## Phase 3 — Review
+
+1. Open Pull Request
+
+2. Provide Codex:
+
+   * Issue
+   * Plan
+   * Diff / PR summary
+
+3. Codex returns:
+
+   * APPROVE / REQUEST CHANGES
+   * Issues and gaps
+   * Missing tests
+   * Risks
+
+4. Apply fixes if needed
+
+5. Merge
+
+---
+
+# 5. Planning Standard (Codex Output)
+
+Every plan MUST include:
+
+1. Objective
+2. Current State
+3. Proposed Approach
+4. Files Likely to Change
+5. Step-by-Step Plan
+6. Test Plan
+7. Risks & Unknowns
+8. Acceptance Criteria
+9. Out of Scope
+
+---
+
+# 6. Implementation Rules (Cursor)
+
+* Follow existing patterns
+* Prefer smallest viable change
+* Keep commits clean and focused
+* Add/update tests for all changes
+* Do not refactor unrelated code
+* Stop and report if ambiguity is found
+
+---
+
+# 7. Required Implementation Output
+
+Cursor must return:
+
+1. Summary
+2. Files Changed
+3. Validation Performed
+4. Remaining Risks
+5. Suggested Commit Message
+
+---
+
+# 8. Review Standard (Codex)
+
+Codex evaluates:
+
+* Acceptance criteria compliance
+* Correctness
+* Regression risk
+* Code quality
+* Security issues
+* Test completeness
+
+Output must include:
+
+* Verdict (APPROVE / REQUEST CHANGES)
+* Criteria check
+* Issues found
+* Missing validation
+* Recommended next step
+
+---
+
+# 9. Branch Naming Convention
+
+feature/<issue>-<short-name>
+fix/<issue>-<short-name>
+chore/<issue>-<short-name>
+
+Examples:
+
+* feature/142-supervisor-claim
+* fix/219-map-latlon-nan
+
+---
+
+# 10. Commit Message Standard
+
+Use structured commits:
+
+* feat: new functionality
+* fix: bug fix
+* test: tests added/updated
+* chore: non-functional changes
+
+Example:
+feat: add supervisor claim workflow
+
+---
+
+# 11. Pull Request Template
+
+## What changed
+
+Summary of implementation
+
+## Why
+
+Link to issue and objective
+
+## Files changed
+
+* path/to/file — reason
+
+## Validation
+
+* Tests:
+* Lint/type-check:
+* Manual verification:
+
+## Acceptance Criteria
+
+* [ ] Criterion 1
+* [ ] Criterion 2
+
+## Risks / Follow-ups
+
+List remaining concerns
+
+---
+
+# 12. Definition of Done
+
+A task is complete when:
+
+* Code implemented
+* Tests pass
+* Acceptance criteria satisfied
+* PR reviewed and approved
+* No critical risks remain
+
+---
+
+# 13. Anti-Patterns (Avoid)
+
+* Coding without a plan
+* Large, multi-purpose PRs
+* Hidden scope expansion
+* Skipping tests
+* Ignoring repo conventions
+* Mixing refactor + feature work
+
+---
+
+# 14. Future Enhancements (Optional)
+
+* GitHub Actions for automated Codex review
+* Auto-generated PR summaries
+* Test coverage enforcement
+* Agent-to-agent feedback loops
+
+---
+
+# 15. Guiding Principle
+
+> “Plan small → Build small → Verify thoroughly → Iterate fast”
+
+---

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Documentation is organized by audience - clear paths for users and developers:
 - **[Troubleshooting](docs/user-guide/TROUBLESHOOTING.md)** - Common issues
 
 ### 🔧 For Developers - How to Build & Extend
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** - Issue-driven workflow, branches, PRs (see [OPERATING.MD](OPERATING.MD))
 - **[Developer Guide](docs/developer-guide/)** - Technical documentation hub
 - **[Makefile Commands](docs/developer-guide/MAKEFILE_COMMANDS.md)** - Complete command reference
 - **[Setup Guide](docs/developer-guide/setup/)** - Development environment
@@ -139,29 +140,19 @@ See [`data/DATABASE_SETUP.md`](data/DATABASE_SETUP.md) for:
 
 RealtyIQ leverages BeeAI Framework workflows to automate complex, multi-step processes by orchestrating multiple agents.
 
+**Execution model:** In the app, workflow **runs are BPMN-only**—each workflow supplies `workflow.bpmn`, `bpmn-bindings.yaml`, and a state class; the engine drives handlers from the diagram. See [workflows/docs/DEVELOPER_GUIDE.md](workflows/docs/DEVELOPER_GUIDE.md) and [docs/architecture/BPMN_ENGINE_REVIEW.md](docs/architecture/BPMN_ENGINE_REVIEW.md).
+
 ### Implemented Workflows
 
 1. **Bidder Onboarding & Verification** ✅
    - Automates complete bidder registration and compliance screening
    - Orchestrates SAM, OFAC, and GRES agents
-   - 8-step workflow with business rules engine
+   - BPMN-defined flow with bound handler methods
    - <5 second execution vs hours manually
 
 ### Quick Start
 
-```python
-from workflows import BidderOnboardingWorkflow
-
-workflow = BidderOnboardingWorkflow()
-result = await workflow.run(
-    bidder_name="John Smith",
-    property_id=12345,
-    registration_data={...}
-)
-
-print(f"Status: {result.state.approval_status}")
-# Status: approved (or denied, pending, review_required)
-```
+Run workflows from the **RealtyIQ UI** (Workflows → start run) or the workflow execution API—not by calling a legacy `workflow.run()` orchestrator. For authoring and the BPMN-ready contract, use the developer guide above.
 
 ### Additional Planned Workflows
 

--- a/agent_ui/agent_app/bpmn_engine.py
+++ b/agent_ui/agent_app/bpmn_engine.py
@@ -631,8 +631,17 @@ def _get_bindings_and_bpmn(workflow_id: str) -> tuple[dict[str, Any], dict[str, 
 
 def can_run_with_bpmn_engine(workflow_id: str) -> bool:
     """
-    Return True if this workflow has BPMN, bindings, and a state class so it can
-    be run with the BPMN engine (diagram-driven execution).
+    Cheap readiness check: True if the workflow looks BPMN-runnable before a run.
+
+    Uses ``get_workflow_context`` to verify BPMN XML is present, bindings normalize
+    to a non-empty ``serviceTasks`` map, the registry exposes a ``state_class_name``,
+    and the first executable element after the start is either a bound service task
+    or an allowed intermediate timer/message catch (same rules as run startup).
+
+    The runner, WebSocket consumer, and tools call this to **fail fast** with a clear
+    message. It is **not** a full static validator: invalid diagrams can still fail
+    later in ``run_bpmn_workflow`` or at save time. The runtime is **BPMN-only**—there
+    is no legacy path when this returns False.
     """
     try:
         context = get_workflow_context(workflow_id)

--- a/agent_ui/agent_app/workflow_runner.py
+++ b/agent_ui/agent_app/workflow_runner.py
@@ -197,6 +197,7 @@ async def _run_executor_to_completion(
     """Run workflow via BPMN engine. Raises FrameworkError, TaskPendingException, or Exception."""
     workflow_id = workflow_run.workflow_id
 
+    # Early readiness (see can_run_with_bpmn_engine docstring); not a legacy fallback gate.
     if not can_run_with_bpmn_engine(workflow_id):
         error_msg = (
             f"Workflow '{workflow_id}' is not BPMN-ready. "

--- a/docs/architecture/BPMN_CONSOLIDATION_TODOS.md
+++ b/docs/architecture/BPMN_CONSOLIDATION_TODOS.md
@@ -12,7 +12,7 @@ See **[BPMN_ENGINE_REVIEW.md](./BPMN_ENGINE_REVIEW.md)** §6 for current-state r
 
 - [ ] Run BPMN-ready workflows (e.g. bi_weekly_report) in production/staging; confirm completion, pause/resume, run-detail UI
 - [ ] Fix any engine or runner bugs found
-- [ ] Document “BPMN-engine-ready workflow” contract in developer guide
+- [x] Document “BPMN-engine-ready workflow” contract in developer guide ([workflows/docs/DEVELOPER_GUIDE.md](../../workflows/docs/DEVELOPER_GUIDE.md) — BPMN-ready workflow contract)
 
 ## Phase 2: Migrate workflows to BPMN-only
 
@@ -24,6 +24,6 @@ See **[BPMN_ENGINE_REVIEW.md](./BPMN_ENGINE_REVIEW.md)** §6 for current-state r
 ## Phase 3: Single execution path
 
 - [x] **Single execution path** – Legacy branch removed; runner and consumers use BPMN engine only. Non–BPMN-ready workflows fail with a clear error.
-- [ ] Simplify or remove `can_run_with_bpmn_engine` (optional; keep for "can this run?" check; execution always requires BPMN)
+- [x] **`can_run_with_bpmn_engine`** – **Kept** as a cheap readiness predicate (BPMN + bindings + state class + valid first executable). Used by the runner, consumers, and tools for fail-fast messaging; it does not enable a non-BPMN fallback. Documented on the function in `bpmn_engine.py`.
 - [x] **Workflow modules** – No Flo `Workflow` / `add_step`; no legacy `run()` in dap_report, bi_weekly_report, property_due_diligence, bidder_onboarding
-- [ ] Update tests and docs for “one execution model: BPMN-driven”
+- [x] **Tests and docs** – Describe BPMN-only execution and supported subset; consolidation cleanup (issue #1). Ongoing: keep architecture docs aligned when engine behavior changes.

--- a/docs/architecture/BPMN_ENGINE_REVIEW.md
+++ b/docs/architecture/BPMN_ENGINE_REVIEW.md
@@ -76,13 +76,9 @@ Rejected at save: nested embedded subprocess, event subprocess, callActivity, an
   - **workflow_runner / consumers:** Integration (when to use engine, state creation, DB/WS updates).  
   This is easy to test and evolve.
 
-### Current scope (v1)
+### Current scope (runtime)
 
-- **Linear / single-path execution**  
-  v1 supports one outgoing sequence flow per element. The engine follows a single path through the diagram.
-
-- **Gateways only partially supported**  
-  Handler-return overrides can influence the next step in some code paths, but there is **no full BPMN semantics** for exclusive gateway conditions, parallel gateway fork/join, or event handling. Multiple outgoing flows from a gateway are not evaluated; execution may stop or use a handler return if implemented.
+Execution is **BPMN-driven** with a **supported subset** of BPMN 2.0, not “linear only.” High-level behavior is summarized at the top of this document (boundary events PAR-014, intermediate catch PAR-015, embedded subprocess PAR-016) and in **§2** (parallel fork/join PAR-005+, exclusive gateways, save-time validation). **Handler return values do not select the next task**—routing follows the diagram (conditions, gateways, tokens).
 
 ### Engine state and persistence
 
@@ -151,7 +147,7 @@ Rejected at save: nested embedded subprocess, event subprocess, callActivity, an
 
 ### Parallel gateway save-time contract (pre-runtime)
 
-Workflow Studio save runs `validate_parallel_gateway_topology()` in [workflow_context.py](../../agent_ui/agent_app/workflow_context.py) via `validate_bpmn_for_save()`. Invalid BPMN is blocked before files are written (API returns 400). This is **stricter** than “any wired gateway” so diagrams match a future deterministic parallel runtime.
+Workflow Studio save runs `validate_parallel_gateway_topology()` in [workflow_context.py](../../agent_ui/agent_app/workflow_context.py) via `validate_bpmn_for_save()`. Invalid BPMN is blocked before files are written (API returns 400). This is **stricter** than “any wired gateway” so diagrams match the **implemented** deterministic parallel fork/join runtime (§2, PAR-005+).
 
 | Role | Allowed topology |
 |------|------------------|
@@ -193,10 +189,10 @@ Hidden catalog workflow [workflows/runner_parallel_fj_test/](../../workflows/run
   - A Pydantic (or compatible) state class with a name ending in `State`.
   - Constructor args that match workflow inputs (e.g. `start_date`, `end_date`).
   - `workflow_steps` on state (or it’s created by the engine).  
-  Workflows that don’t follow this (e.g. DAP report) correctly fall back to `executor.run()` but are undocumented; a short “BPMN-engine-ready workflow contract” in the dev guide would help.
+  Execution is **BPMN-only**; workflows without this contract are not runnable until they expose BPMN, bindings, and a state class (see [workflows/docs/DEVELOPER_GUIDE.md](../../workflows/docs/DEVELOPER_GUIDE.md)).
 
-- **Handler return value ignored**  
-  Handlers can return a next step name; the engine ignores it and always uses `get_next_task_id(bpmn, current)`. That’s correct for “diagram is source of truth,” but it means you cannot implement conditional next steps in code without extending the engine (e.g. optional override when handler returns a non-empty string).
+- **Handler return value and routing**  
+  Handlers may return values for logging; **routing does not follow handler return strings**. Conditional branching is expressed in the diagram (e.g. exclusive gateway conditions), not by returning the next task id from Python.
 
 - **Per-branch cancellation / per-task timeout**  
   Workflow-level cooperative cancellation and optional run timeout are implemented (see §8). Per-branch cancellation and per-task timeouts remain out of scope.
@@ -258,7 +254,7 @@ Hidden catalog workflow [workflows/runner_parallel_fj_test/](../../workflows/run
   If `create_initial_state_from_inputs` raises (e.g. wrong or missing input keys), the exception propagates and the run is marked failed. There is no fallback to `executor.run()` in that case. That’s correct (inputs are invalid), but the error_message could be explicit, e.g. “BPMN engine: failed to create initial state: …”, so logs and UI are clearer.
 
 - **Duplicate context loading**  
-  `can_run_with_bpmn_engine` and `_get_bindings_and_bpmn` both call `get_workflow_context(workflow_id)`. For a single run you may call the former once and the latter once, so context is loaded twice. Minor cost; could be optimized later by caching per run or by having a single “get context and decide execution mode” helper.
+  `can_run_with_bpmn_engine` and `_get_bindings_and_bpmn` both call `get_workflow_context(workflow_id)`. For a single run you may call the former once and the latter once, so context is loaded twice. Minor cost; could be optimized later by caching per run or by combining readiness checks with the first BPMN/bindings load.
 
 - **Resume: state reconstruction**  
   On resume, state is rebuilt from `progress_data["state_data"]` (e.g. `model_dump()`). Attributes that are not on the Pydantic model (e.g. `_bpmn_next_step`) are not persisted. That’s fine because the next step is stored in `progress_data["next_step"]` and the engine uses `start_from_task_id` on resume. No issue here.
@@ -276,67 +272,62 @@ Hidden catalog workflow [workflows/runner_parallel_fj_test/](../../workflows/run
    In the runner, when the BPMN path raises (and it’s not `TaskPendingException`), call `_update_workflow_progress_sync(run_id, {"failed_node_id": current_task_id})` before marking the run failed, so the UI can highlight the failing task.
 
 2. **Document the “BPMN-engine-ready” contract**  
-   In the developer guide or workflow docs: workflow must have a state class in `workflow.py`, BPMN with at least one service task, and bindings; state constructor must accept workflow inputs; handlers must be methods on the executor and take `(self, state)`.
+   **Done** in [workflows/docs/DEVELOPER_GUIDE.md](../../workflows/docs/DEVELOPER_GUIDE.md) (BPMN-ready workflow contract). Keep it updated when the supported subset changes.
 
 3. **Clarify errors from state creation**  
-   When catching exceptions in `execute_workflow_run` that originate from `create_initial_state_from_inputs` or from the BPMN engine, set `error_message` to something like “BPMN engine: …” so support can tell diagram-driven runs from legacy runs.
+   When catching exceptions in `execute_workflow_run` that originate from `create_initial_state_from_inputs` or from the BPMN engine, set `error_message` to something like “BPMN engine: …” for support clarity (all runs are diagram-driven; there is no legacy executor path).
 
 **Medium term**
 
-4. **Support exclusive gateways**  
-   When an element has multiple outgoing flows, evaluate conditions (e.g. from flow or extension) and choose one path; then continue with `_follow_single_path` from the chosen target. This keeps the engine single-path per execution but allows conditional branches.
+4. **Exclusive gateways** — Implemented (condition evaluation on outgoing flows); see §2. Further BPMN constructs remain in [BPMN_V2_PLAN.md](BPMN_V2_PLAN.md).
 
 5. **Optional handler override for “next”**  
-   If a handler returns a non-empty string (task id), use it as the next task id when it exists in the diagram; otherwise use `get_next_task_id`. Enables rare cases where code must override diagram order without changing the XML.
+   If product needs code-selected next task ids, extend the engine explicitly; today handler return strings are not used for routing.
 
 6. **Caching of workflow context**  
-   For the same `workflow_id` in a request or run, reuse the result of `get_workflow_context` (or at least BPMN + bindings) to avoid repeated file/registry access. Invalidate or TTL when versions change if you support hot-reload.
+   For the same `workflow_id` in a request or run, reuse the result of `get_workflow_context` (or at least BPMN + bindings) to avoid repeated file/registry access. `can_run_with_bpmn_engine` and `_get_bindings_and_bpmn` each load context today (minor duplication).
 
 **Lower priority**
 
 7. **Nested parallel regions**  
    Fork/join pairs are single-level; nested forks after a fork are rejected with **`join_correlation_failed`**.
 
-8. **Timeouts**  
-   Add optional per-task or per-run timeouts and ensure the runner can mark the run as failed and set `failed_node_id` when a timeout occurs.
+8. **Per-task timeouts**  
+   Workflow-level / run timeout is implemented (§8, PAR-010). Optional per-task timeouts remain a future enhancement.
 
 ---
 
 ## 5. Verdict
 
-The design is sound and fits the goal: **diagram-driven execution for linear workflows**, with a clear fallback to the existing executor and correct pause/resume. The implementation is consistent with the rest of the codebase and keeps the BPMN engine focused on orchestration while reusing parsing and runner lifecycle.
+The design fits the goal: **diagram-driven, BPMN-only execution** with a **growing but explicit supported subset** (parallel fork/join, exclusive gateways, boundaries, intermediate catch, embedded subprocess phase 1, cancel/timeout, retries). There is **no legacy `executor.run()` path**; non–BPMN-ready workflows fail fast via `can_run_with_bpmn_engine` and clear errors in the runner.
 
-The main limitations are **intentional** (linear only, no gateways) and should be documented. The suggested improvements are incremental (failure reporting, docs, optional overrides, then gateways/timeouts) and do not require a redesign.
-
-**Recommendation:** Treat the current implementation as the v1 BPMN engine, document its contract and limitations, and add the high-value, low-effort items (failed_node_id, error messaging, docs) soon. Plan gateway support and optional handler override as v2 when you have workflows that need them. See [BPMN_V2_PLAN.md](BPMN_V2_PLAN.md) for the v2 BPMN semantics plan (exclusive/parallel gateways, failure reporting, cancellation/timeout).
+Remaining work is **incremental** (failure UX, optional handler overrides, deeper BPMN coverage per [BPMN_V2_PLAN.md](BPMN_V2_PLAN.md)) and **operational validation** in staging/production—not a second execution model.
 
 ---
 
 ## 6. Consolidation TODOs (single execution model)
 
-**Goal:** Once the BPMN engine is proven in production, migrate all workflows to it and remove the legacy “Python step chain” path so there is **only one way** to execute flows. This simplifies code and avoids two parallel patterns.
+**Status:** Consolidation to a **single BPMN-driven path** is **done** in code. Below distinguishes **operational follow-up** from **optional cleanup**.
 
-- [ ] **Validate BPMN engine in production** – Run bi_weekly_report (and any other BPMN-ready workflow) via the engine for a period; confirm completion, pause/resume, and run-detail UI (e.g. completed_node_ids). Fix any bugs before consolidation.
-- [ ] **Document BPMN-engine contract** – Add a “BPMN-engine-ready workflow” section to the developer guide: state class in workflow.py, BPMN + bindings, handler `(self, state)` signature, input_schema → state constructor. List which workflows are already compatible.
-- [ ] **Migrate bi_weekly_report to BPMN-only** – Remove `_register_steps()` and `self.workflow.add_step(...)`; keep only handler methods. Remove or simplify `run()` so it only builds initial state (or leave a minimal `run()` that the runner no longer uses when `can_run_with_bpmn_engine` is True). Ensure BPMN + bindings fully define order.
-- [ ] **Migrate property_due_diligence to BPMN engine** – Same as above: add/align BPMN and bindings, introduce a state class if missing, implement handlers as methods, remove step registration and legacy `run()` orchestration.
-- [ ] **Migrate bidder_onboarding to BPMN engine** – Same pattern; preserve human-task pause/resume via TaskPendingException and ensure next_step is the BPMN task id.
-- [ ] **Migrate dap_report (or decide out-of-scope)** – DAP report uses a different pattern (no Flo state class). Either refactor to a BPMN-engine-ready state + handlers, or explicitly keep it on legacy `executor.run()` and document why.
-- [ ] **Remove legacy execution path** – Once all supported workflows run via the BPMN engine, remove the `else` branch in `_run_executor_to_completion` that calls `executor_instance.run(**input_data)`. Remove or deprecate `can_run_with_bpmn_engine` (always use engine when BPMN+bindings+state exist) and any consumer/runner code that only runs the old step chain.
-- [ ] **Simplify workflow base / Flo usage** – If no workflow still uses `Workflow.add_step()` and `workflow.run(initial_state)`, consider removing or simplifying the Flo `Workflow` class usage in workflow modules so that only handler methods and state remain; the BPMN engine owns orchestration.
-- [ ] **Update tests and docs** – Update any tests that assume the old step chain or `executor.run()`. Update READMEs, USER_STORY, and architecture docs to describe “one execution model: BPMN-driven.”
+- [ ] **Validate BPMN engine in production** – Run key workflows in production/staging; confirm completion, pause/resume, run-detail UI, parallel/join displays. Fix bugs as found.
+- [x] **Document BPMN-engine contract** – [workflows/docs/DEVELOPER_GUIDE.md](../../workflows/docs/DEVELOPER_GUIDE.md) (BPMN-ready workflow contract + supported subset / limitations).
+- [x] **Migrate supported workflows to BPMN-only** – dap_report, bi_weekly_report, property_due_diligence, bidder_onboarding (and catalog tests) use BPMN + bindings + state; no legacy `run()` orchestration.
+- [x] **Remove legacy execution path** – `_run_executor_to_completion` uses only the BPMN engine.
+- [x] **`can_run_with_bpmn_engine`** – **Retained** as an early readiness check (BPMN, bindings, state class, first executable). Documented in `bpmn_engine.py`; used by runner, consumers, and tools—not a fallback switch.
+- [ ] **Simplify workflow base / Flo usage** – Optional: further trim unused Flo `Workflow` / `add_step` patterns in workflow modules if none remain.
+- [x] **Tests and docs for one execution model** – Architecture + developer docs describe BPMN-only runtime; BPMN test suites cover engine, integration, conformance (ongoing maintenance).
 
 ---
 
-## 7. Design: Parallel gateways (next milestone)
+## 7. Design notes: Parallel gateways (reference)
 
-This section is a **design-only** pass before implementing parallel gateways. No implementation is implied; the intent is to agree on semantics and data shapes so that a future implementation stays consistent.
+**Runtime status:** Parallel fork/join and multi-token execution are **implemented**; see **§2** (PAR-005+), [bpmn_parallel.py](../../agent_ui/agent_app/bpmn_parallel.py), and conformance tests. The subsections below record **design intent** and **UI/resume considerations** that informed the implementation; they are not a “future-only” spec.
 
 ### Multi-token schema
 
-- **Representation:** The engine already reserves `branch_id` on each token. For parallel gateways, **multiple active tokens** will be allowed: one per branch after a parallel fork. Each token has `current_element_id` and `branch_id` (e.g. a UUID or a stable branch index). The `active_tokens` list in engine state will hold more than one entry while branches are in progress.
-- **Mapping to branches:** When the engine hits a parallel gateway (fork), it will create one new token per outgoing sequence flow and advance each token to the flow's target. The original token is retired; the new tokens share the same "fork point" in the diagram but are independent until join.
-- **Single-token today:** Current v2 engine uses a single token; the list structure and reserved `branch_id` are already in place so that adding multiple tokens is an extension of the same schema.
+- **Representation:** The engine reserves `branch_id` on each token. After a **parallel fork**, **multiple active tokens** exist: one per outgoing flow. Each token has `current_element_id` and `branch_id` (e.g. `{fork_id}:{flow_id}`). The `active_tokens` list holds more than one entry while branches are in progress.
+- **Mapping to branches:** When the engine hits a parallel gateway (fork), it creates one new token per outgoing sequence flow and advances each token to the flow's target. The original token is retired; the new tokens share the same fork point but are independent until join.
+- **Schema:** Multi-token state is normalized on load (`normalize_engine_state`); see §1 engine-state table.
 
 ### Join semantics
 
@@ -358,20 +349,18 @@ This section is a **design-only** pass before implementing parallel gateways. No
 
 ### Scaffolding (for implementers)
 
-**Canonical helper layer:** [agent_app/bpmn_parallel.py](../../agent_ui/agent_app/bpmn_parallel.py) is the single module for parallel token/join bookkeeping until fork/join runtime lands in the engine. It is engine-agnostic (no BPMN traversal, handlers, DB, or Django). Unit tests: `test_bpmn_parallel_scaffolding.py`.
+**Canonical helper layer:** [agent_app/bpmn_parallel.py](../../agent_ui/agent_app/bpmn_parallel.py) is the module for parallel token/join bookkeeping used by the engine. It is engine-agnostic (no BPMN traversal, handlers, DB, or Django). Unit tests: `test_bpmn_parallel_scaffolding.py`.
 
 **Token helpers:** `ensure_active_tokens`, `token_dict`, `append_token`, `replace_token_at_index`, `replace_token_by_branch_id`, `tokens_at_element`, `tokens_at_join`, `active_element_ids`, `active_branch_ids`, `remove_tokens_by_branch_ids`. `remove_tokens_by_branch_ids` drops any non-dict entries in `active_tokens` (malformed tokens are not preserved); parallel runtime should rely on normalized state after load.
 
 **Join helpers:** `ensure_pending_joins`, `PendingJoinInfo`, `register_pending_join`, `get_pending_join`, `is_join_satisfied`, `mark_branch_arrived_at_join` (idempotent per branch), `clear_pending_join`.
 
-When implementing parallel gateways, the following extension points apply (no full fork/join in the main loop yet):
+**Extension points** (implemented in engine + runner):
 
-- **Multi-token state model:** `BpmnEngineStateSchema` documents `active_tokens`, `pending_joins`, and failure metadata alongside list fields; use `branch_id` on each token at a parallel fork.
-- **Join bookkeeping:** `pending_joins` on engine state holds `PendingJoinInfo`-shaped dicts per join element id so the engine can tell when all sibling branches have arrived.
-- **Progress representation for multiple active nodes:** `current_node_ids` can remain a list; with multiple tokens it becomes the list of `current_element_id` from each active token. The UI and `progress_data` already pass lists; no change to the shape, only to how the list is populated.
-- **Pause/resume with more than one active branch:** Persist `active_tokens` as today; on resume, restore all tokens and run the main loop once per active token (or in a round-robin). No change to `progress_data` keys; only the number of entries in `active_tokens` and the resume loop logic.
-
-Implementation of the above is deferred until this design is agreed and prioritized.
+- **Multi-token state model:** `active_tokens`, `pending_joins`, and failure metadata; `branch_id` on each token at a parallel fork.
+- **Join bookkeeping:** `pending_joins` holds `PendingJoinInfo`-shaped dicts per join element id until all expected branches arrive.
+- **Progress representation:** `current_node_ids_for_progress` derives multiple current nodes from tokens (PAR-008).
+- **Pause/resume:** Full `active_tokens` persist in `progress_data`; resume must not collapse tokens incorrectly (see §1 and integration tests).
 
 ## Verification
 

--- a/docs/architecture/BPMN_V2_PLAN.md
+++ b/docs/architecture/BPMN_V2_PLAN.md
@@ -2,33 +2,40 @@
 
 **Status:** Proposed architecture and implementation design.  
 **Audience:** Workflow engine maintainers, Workflow Studio maintainers, backend developers.  
-**Scope:** Expand the current BPMN v1 engine from linear diagram-driven execution into a safer, richer BPMN runtime with true branching semantics, better persistence, and stronger operational controls.
+**Scope:** Extend the **current** BPMN runtime (already token-based with parallel fork/join, exclusive gateways, boundaries, intermediate catch, embedded subprocess phase 1, cancel/timeout, retries—see [BPMN_ENGINE_REVIEW.md](./BPMN_ENGINE_REVIEW.md)) toward **fuller BPMN 2.0** semantics, stronger operational controls, and clearer evolution paths.
 
 ---
 
 ## 1. Summary
 
-The current BPMN engine is a strong v1 for **linear, single-path workflows**. It is intentionally limited: it can traverse a BPMN diagram, invoke bound handlers, pause/resume on human tasks, and update UI progress. It does **not** yet provide full BPMN 2.0 execution semantics.
+Today’s engine is **BPMN-only** and supports a **documented subset** of BPMN 2.0 (not merely linear diagrams). It remains **not** a complete BPMN 2.0 execution environment: unsupported constructs and edge cases are called out in the engine review and save-time validation.
 
-V2 upgrades the engine from:
+V2 (this spec) targets **further** upgrades beyond the current baseline, for example:
+
+- deeper coverage of BPMN constructs and stricter operational guarantees
+- richer failure/retry policies and observability
+- optional features still called out as future work in the review (e.g. some handler-override semantics, per-task timeouts, nested parallel regions)
+
+Historical contrast (pre–parallel-gateway era)—the engine used to be conceptualized as:
 
 - one current task
 - one path through the graph
-- lightweight handler-return overrides
 
-to:
+The **current** baseline already includes:
 
-- a **token-based execution runtime**
+- a **token-based** execution model (multi-token after parallel fork)
 - **exclusive gateway** condition evaluation
-- **parallel gateway** fork/join execution
-- **timeout**, **cancellation**, and **retry** policies
-- richer persisted engine state and better failure reporting
+- **parallel gateway** fork/join (with save-time correlation rules)
+- workflow-level **timeout**, **cancellation**, and **task retry** policies
+- richer persisted engine state (see `normalize_engine_state`)
 
-This spec defines the intended behavior, architecture boundaries, persistence model, rollout plan, and the main files that should change.
+This spec defines additional intended behavior, architecture boundaries, persistence evolution, rollout plan, and the main files that should change as the runtime moves toward fuller BPMN 2.0 coverage.
 
 ---
 
 ## 2. Goals
+
+**Note:** The **current** runtime already implements exclusive and parallel gateways (with constraints), token persistence, pause/resume across branches, workflow-level cancel/timeout, task retries, and BPMN run diagnostics. The goals below describe **V2 evolution**—tightening semantics, extending BPMN coverage, and operational hardening—not a from-scratch engine.
 
 ### Primary goals
 

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -188,8 +188,10 @@ async def register_bidder(request):
 
 ## Workflow Design Patterns
 
+**Runtime:** Workflow execution is **BPMN-only**—order, branching, and parallel regions are defined in `workflow.bpmn` and `bpmn-bindings.yaml`, not by registering a Python step chain. See [docs/DEVELOPER_GUIDE.md](docs/DEVELOPER_GUIDE.md). The patterns below illustrate **conceptual** control flow; map them to BPMN tasks, gateways, and subprocesses in your diagram.
+
 ### 1. Sequential Processing
-Linear flow through steps in order:
+Linear flow through steps in order (express as sequential BPMN tasks; historical Flo-style example):
 ```python
 workflow.add_step("step1", step1_handler)
 workflow.add_step("step2", step2_handler)

--- a/workflows/docs/DEVELOPER_GUIDE.md
+++ b/workflows/docs/DEVELOPER_GUIDE.md
@@ -172,8 +172,7 @@ Handler rules:
 
 - handlers must be instance methods on the executor class
 - handlers must accept `state` as the primary input
-- handlers may return `None`
-- handlers may return a BPMN task id string to override the next step in limited cases
+- handlers may return `None` or other values for logging; **routing follows the BPMN diagram** (sequence flow, exclusive gateway conditions, parallel fork/join, etc.)—do not rely on return values to pick the next task
 - helper methods are fine, but only bound handlers are invoked by the BPMN engine
 
 **Required state contract**
@@ -205,7 +204,7 @@ The BPMN diagram must include:
 - valid sequence flow connections
 - task ids that match entries in `bpmn-bindings.yaml`
 
-For the current engine, diagrams should be designed as **linear / single-path** unless you are intentionally using the limited handler-return override behavior.
+The runtime supports a **documented subset** of BPMN 2.0: single-path flows, **exclusive** and **parallel** gateways (with save-time topology checks), **interrupting** boundary timer/error on tasks, **intermediate** timer/message catch (with resume semantics), **embedded subprocess** (single level, no nesting), task retries, and workflow-level cancel/timeout. Unsupported shapes are rejected at save or fail at runtime with a clear error—see [BPMN_ENGINE_REVIEW.md](../../docs/architecture/BPMN_ENGINE_REVIEW.md) (top sections and §2).
 
 **Required bindings contract**
 
@@ -278,12 +277,12 @@ Before marking a workflow ready, confirm:
 
 For engine limitations and architecture details, see [BPMN_ENGINE_REVIEW.md](../../docs/architecture/BPMN_ENGINE_REVIEW.md).
 
-**Limitations (v1 engine)**
+**Limitations and unsupported BPMN**
 
-- Execution is **linear / single-path**. Multiple outgoing flows from a gateway are not fully evaluated; the engine may stop or use a handler return override if implemented.
-- No full BPMN semantics in v1: no native exclusive gateway condition evaluation, no true parallel gateway fork/join, no event-node or subprocess semantics.
-- For future branching semantics and runtime evolution, see [BPMN_V2_PLAN.md](../../docs/architecture/BPMN_V2_PLAN.md).
-- Consolidation status: [BPMN_CONSOLIDATION_TODOS.md](../../docs/architecture/BPMN_CONSOLIDATION_TODOS.md).
+- **Not full BPMN 2.0**: many constructs are unsupported or only partially supported (e.g. callActivity, nested embedded subprocess, event subprocess, non-interrupting boundaries, intermediate catch with **multiple active parallel tokens**—see PAR-015 in [BPMN_ENGINE_REVIEW.md](../../docs/architecture/BPMN_ENGINE_REVIEW.md)).
+- **Parallel regions**: fork/join correlation and branch shapes are constrained by `validate_bpmn_for_save` and runtime checks; nested parallel forks on a branch are rejected.
+- **Handler returns** do not override diagram routing.
+- Roadmap and longer-term semantics: [BPMN_V2_PLAN.md](../../docs/architecture/BPMN_V2_PLAN.md). Consolidation status: [BPMN_CONSOLIDATION_TODOS.md](../../docs/architecture/BPMN_CONSOLIDATION_TODOS.md).
 
 ---
 


### PR DESCRIPTION
Closes #1

## Summary
- Align docs with BPMN-only execution (`can_run_with_bpmn_engine`, architecture notes, README).
- Add CONTRIBUTING, OPERATING.MD, PR template, and Codex PR review workflow.

## Validation
- CI: Codex PR Review workflow present; secret gated as documented.

Made with [Cursor](https://cursor.com)