### PR TITLE
chore: BPMN real-environment validation procedure (issue #7)

### DIFF
--- a/docs/architecture/BPMN_CONSOLIDATION_TODOS.md
+++ b/docs/architecture/BPMN_CONSOLIDATION_TODOS.md
@@ -10,8 +10,9 @@ See **[BPMN_ENGINE_REVIEW.md](./BPMN_ENGINE_REVIEW.md)** §6 for current-state r
 
 ## Phase 1: Validate engine
 
-- [ ] Run BPMN-ready workflows (e.g. bi_weekly_report) in production/staging; confirm completion, pause/resume, run-detail UI
-- [ ] Fix any engine or runner bugs found
+- [ ] Run BPMN-ready workflows (e.g. bi_weekly_report) in production/staging; confirm completion, pause/resume, run-detail UI  
+  - **Issue #7 — procedure and matrix:** [BPMN_STAGING_VALIDATION.md](../operations/BPMN_STAGING_VALIDATION.md) lists catalog workflows, data prerequisites, automated integration coverage (`test_workflow_runner_integration.py`), parallel/join strategy (`runner_parallel_fj_test` + tests), and **empty staging/production tables** for operators to fill with run IDs. **Remaining gap:** complete those tables in a real deployment, then check this item off.
+- [x] Fix any engine or runner bugs found — **none found** during Issue #7 doc work; file new issues if staging exercises reveal defects
 - [x] Document “BPMN-engine-ready workflow” contract in developer guide ([workflows/docs/DEVELOPER_GUIDE.md](../../workflows/docs/DEVELOPER_GUIDE.md) — BPMN-ready workflow contract)
 
 ## Phase 2: Migrate workflows to BPMN-only

--- a/docs/operations/BPMN_RUN_OPERATORS.md
+++ b/docs/operations/BPMN_RUN_OPERATORS.md
@@ -38,3 +38,5 @@ When branches must meet at a **parallel join gateway**, the engine records **how
 ## Where this is implemented
 
 Run detail builds a **textual timeline** and **diagnostics panel** from persisted `progress_data` (no change to engine semantics). See [BPMN engine review](../architecture/BPMN_ENGINE_REVIEW.md) for architecture.
+
+For **staging/production validation** checklists (run IDs, completion / pause / UI / parallel join), see [BPMN_STAGING_VALIDATION.md](./BPMN_STAGING_VALIDATION.md).

--- a/docs/operations/BPMN_STAGING_VALIDATION.md
+++ b/docs/operations/BPMN_STAGING_VALIDATION.md
@@ -1,0 +1,106 @@
+# BPMN real-environment validation (Issue #7)
+
+This document records **how** to validate BPMN-only workflow execution outside local unit tests, and **where** to capture evidence. It complements [BPMN_RUN_OPERATORS.md](./BPMN_RUN_OPERATORS.md) (expected run-detail semantics).
+
+## 1. Preconditions (record per exercise)
+
+| Field | Value (fill when validating) |
+|-------|------------------------------|
+| **Environment** | e.g. staging URL or production (name only in git; no secrets) |
+| **Date** | |
+| **Operator** | |
+| **App version / commit** | e.g. git SHA deployed |
+
+**Catalog-visible BPMN workflows** (default registry list; `hide_from_catalog` workflows are excluded from the Workflows UI):
+
+| Workflow ID | Notes / data prerequisites |
+|-------------|----------------------------|
+| `bidder_onboarding` | Inputs: `bidder_name`, `email`, `phone`, `property_id`, `age_accepted`, `terms_accepted`. External SAM/OFAC behavior depends on environment configuration. |
+| `property_due_diligence` | Requires a valid `property_id` for your environment’s data sources. |
+| `bi_weekly_report` | Requires `start_date` and `end_date` (report window); uses portfolio/agents as configured. |
+| `dap_report` | Requires `report_date`; optional `lookback_days`. DAP agent availability affects outcome. |
+
+Confirm each workflow appears under **Workflows** in the UI before treating the environment as ready.
+
+## 2. Automated baseline (local / CI)
+
+These tests exercise the **same** runner and persistence paths as the app (`execute_workflow_run`, `resume_bpmn_after_pause`, `progress_data`, fork/join). They do **not** replace staging UI validation.
+
+From repo root (with Django test DB available and no other process holding `agent_ui/db.sqlite3`):
+
+```bash
+cd agent_ui && ../venv/bin/python -m pytest agent_app/tests/test_workflow_runner_integration.py -q
+```
+
+Coverage highlights (see file for full list):
+
+- **`runner_integration_test`** — pause for human task, resume, completed steps, failure / retry metadata.
+- **`runner_parallel_fj_test`** — parallel fork/join completion, pause before join + resume, pending joins, branch failure, cancel, timeout scenarios.
+- **`par015_message_runner`** — intermediate message catch + resume.
+
+Product workflows (`dap_report`, `bi_weekly_report`, etc.) are not the subject of this module; validate them in the matrix below in a real deployment.
+
+## 3. Staging / production validation matrix
+
+For each workflow, run from the **Workflows** UI (or equivalent API), then open **run detail**. Record **run id** from the UI or URL.
+
+### 3.1 Completion (happy path)
+
+| Workflow ID | Run ID | Pass / Fail / Skip | Notes |
+|---------------|--------|--------------------|-------|
+| `dap_report` | | | |
+| `bi_weekly_report` | | | |
+| `property_due_diligence` | | | |
+| `bidder_onboarding` | | | |
+
+### 3.2 Pause / resume
+
+Use a workflow that reaches **Waiting for task** (human step). Confirm resume continues from the documented task / resume point.
+
+| Workflow ID | Run ID | Pass / Fail / Skip | Notes |
+|---------------|--------|--------------------|-------|
+| | | | |
+
+### 3.3 Run-detail UI (progress, current / completed nodes)
+
+Compare timeline and diagnostics to [BPMN_RUN_OPERATORS.md](./BPMN_RUN_OPERATORS.md).
+
+| Workflow ID | Run ID | Pass / Fail / Skip | Notes |
+|---------------|--------|--------------------|-------|
+| | | | |
+
+### 3.4 Failure presentation (controlled)
+
+Prefer invalid inputs, sandbox data, or a non-production environment. Capture **failed node** and message when applicable.
+
+| Workflow ID | Run ID | Pass / Fail / Skip | Notes |
+|---------------|--------|--------------------|-------|
+| | | | |
+
+## 4. Parallel fork / join (UI vs automated)
+
+**Repository fact:** The only committed BPMN with parallel gateways is **`runner_parallel_fj_test`**, which sets `hide_from_catalog: true` and does not appear on the default Workflows list.
+
+**Chosen validation method for fork/join engine + persistence:**
+
+1. **Primary:** Automated tests in `agent_app/tests/test_workflow_runner_integration.py` (`RunnerParallelFjIntegrationTests`).
+2. **Optional in a deployed environment:** Start `runner_parallel_fj_test` via internal API or temporarily expose it (e.g. staging-only branch with `hide_from_catalog: false`) strictly for validation—then restore.
+
+Record here if a **live UI** parallel run was performed:
+
+| Method | Environment | Run ID | Pass / Fail / Skip | Notes |
+|--------|-------------|--------|--------------------|-------|
+| Integration tests only | CI / local | N/A | | |
+| Live UI or API | | | | |
+
+## 5. Bugs and follow-ups
+
+If a defect is found during real-environment runs, file a **new GitHub issue** with run id, workflow id, expected vs actual, and screenshots. Link it from this section when updating the doc after triage.
+
+| Issue | Summary |
+|-------|---------|
+| | |
+
+---
+
+**Status:** Automated baseline is defined above. **Staging/production table rows are intentionally left for operators** to fill after exercises. When those rows are completed and any bugs are filed or fixed, update [BPMN_CONSOLIDATION_TODOS.md](../architecture/BPMN_CONSOLIDATION_TODOS.md) Phase 1 accordingly.


### PR DESCRIPTION
## What changed

- Added [docs/operations/BPMN_STAGING_VALIDATION.md](docs/operations/BPMN_STAGING_VALIDATION.md): preconditions, catalog-visible BPMN workflows and input prerequisites, automated baseline (`test_workflow_runner_integration.py`), empty staging/production matrices for operators to fill with run IDs, and parallel fork/join strategy (`runner_parallel_fj_test` + tests vs optional live UI/API).
- Updated [docs/architecture/BPMN_CONSOLIDATION_TODOS.md](docs/architecture/BPMN_CONSOLIDATION_TODOS.md) Phase 1: link Issue #7 to the new doc, mark bug-fix line as satisfied for doc-only pass (none found here), leave the real-environment checkbox open until tables are completed in deployment.
- Linked the validation doc from [docs/operations/BPMN_RUN_OPERATORS.md](docs/operations/BPMN_RUN_OPERATORS.md).

## Why

- Issue: #7
- Objective: Close the operational gap for BPMN consolidation by documenting how to validate runs in staging/production and what is already covered by integration tests, without faking run IDs we cannot obtain from this environment.

## Approved Plan

Issue #7 plan: validation-and-documentation; environment-dependent execution stays with operators; code fixes only if defects found (none in this change set).

## Scope Check

- [x] Change stays within the approved plan
- [x] No unrelated refactors
- [x] Tests updated only where needed (N/A — docs only)

## Files changed

- `docs/operations/BPMN_STAGING_VALIDATION.md` — validation procedure and matrices
- `docs/architecture/BPMN_CONSOLIDATION_TODOS.md` — Phase 1 status
- `docs/operations/BPMN_RUN_OPERATORS.md` — cross-link

## Validation

- Tests: Not run for this PR (documentation only). Local `pytest agent_app/tests/test_workflow_runner_integration.py` hit `database is locked` on shared `db.sqlite3`; CI should run the suite on a clean DB.
- Lint/type-check: N/A
- Manual verification: Review doc links and checklist structure

## Acceptance Criteria

- [x] Key workflows identified and matrices provided for real-environment exercise
- [ ] Completion / pause-resume / run-detail verified in staging/production — **operator completes [BPMN_STAGING_VALIDATION.md](docs/operations/BPMN_STAGING_VALIDATION.md) tables** (remaining gap documented in consolidation TODOs)
- [x] Parallel/join approach documented (tests + optional live path)
- [x] Bugs: none found in this pass; follow-up issues if staging finds defects
- [x] BPMN consolidation docs updated

## Remaining Risks

Staging/production tables are empty until someone runs the exercises.

## Follow-ups

After filling matrices in a real deployment, check off Phase 1 first item in `BPMN_CONSOLIDATION_TODOS.md` and optionally paste run IDs into this PR or the doc.

Refs #7

Made with [Cursor](https://cursor.com)
