### PR TITLE
fix(issue-9): lock gateway routing behavior in runner path

### DIFF
--- a/agent_ui/agent_app/bpmn_engine.py
+++ b/agent_ui/agent_app/bpmn_engine.py
@@ -628,10 +628,24 @@ def select_exclusive_flow(
         gateway_element_id,
         ", ".join(f"{x['flow_id']}={x.get('result', '?')}" for x in evaluated),
     )
+    sanitized_evaluated = []
+    for item in evaluated:
+        if not isinstance(item, dict):
+            continue
+        sanitized_evaluated.append(
+            {
+                "flow_id": str(item.get("flow_id", "")),
+                "target_id": str(item.get("target_id", "")),
+                "condition": str(item.get("condition", ""))[:120],
+                "result": bool(item.get("result", False)),
+                "error": str(item.get("error", ""))[:240] if item.get("error") else "",
+            }
+        )
+
     failure_meta = {
         "gateway_element_id": gateway_element_id,
-        "default_flow_id": default_flow_id,
-        "evaluated_flows": evaluated,
+        "default_flow_id": str(default_flow_id or ""),
+        "evaluated_flows": sanitized_evaluated,
     }
     exc = ValueError(
         f"Exclusive gateway '{gateway_element_id}' has no matching condition and no default flow."

--- a/agent_ui/agent_app/bpmn_engine.py
+++ b/agent_ui/agent_app/bpmn_engine.py
@@ -628,9 +628,17 @@ def select_exclusive_flow(
         gateway_element_id,
         ", ".join(f"{x['flow_id']}={x.get('result', '?')}" for x in evaluated),
     )
-    raise ValueError(
+    failure_meta = {
+        "gateway_element_id": gateway_element_id,
+        "default_flow_id": default_flow_id,
+        "evaluated_flows": evaluated,
+    }
+    exc = ValueError(
         f"Exclusive gateway '{gateway_element_id}' has no matching condition and no default flow."
     )
+    # Preserve structured context so runner-path failures can expose real gateway diagnostics.
+    setattr(exc, "gateway_failure_metadata", failure_meta)
+    raise exc
 
 
 def _get_bindings_and_bpmn(workflow_id: str) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -1259,13 +1267,17 @@ def _resolve_task_execution_context(
             bpmn, current, state, bindings, flow_selector
         )
     except ValueError as e:
+        meta = {"message": str(e)}
+        gateway_meta = getattr(e, "gateway_failure_metadata", None)
+        if isinstance(gateway_meta, dict):
+            meta.update(gateway_meta)
         _raise_engine_failure(
             message=str(e),
             state=state,
             engine_state=engine_state,
             failure_reason="invalid_gateway",
             failed_node_id=current,
-            condition_failure_metadata={"message": str(e)},
+            condition_failure_metadata=meta,
             cause=e,
         )
 
@@ -1630,13 +1642,17 @@ async def run_bpmn_workflow(  # noqa: C901
                 bpmn, current, state, bindings, _flow_selector
             )
         except ValueError as e:
+            meta = {"message": str(e)}
+            gateway_meta = getattr(e, "gateway_failure_metadata", None)
+            if isinstance(gateway_meta, dict):
+                meta.update(gateway_meta)
             _raise_engine_failure(
                 message=str(e),
                 state=state,
                 engine_state=engine_state,
                 failure_reason="invalid_gateway",
                 failed_node_id=current,
-                condition_failure_metadata={"message": str(e)},
+                condition_failure_metadata=meta,
                 cause=e,
             )
 

--- a/agent_ui/agent_app/tests/test_bpmn_integration.py
+++ b/agent_ui/agent_app/tests/test_bpmn_integration.py
@@ -4,6 +4,7 @@ Uses real run_bpmn_workflow and fixtures; no full stack (DB/WS).
 """
 
 import asyncio
+import json
 
 from django.test import TestCase
 
@@ -377,3 +378,6 @@ class BpmnIntegrationTests(TestCase):
         self.assertIsNotNone(e.condition_failure_metadata)
         self.assertIn("message", e.condition_failure_metadata)
         self.assertIn("no matching condition", e.condition_failure_metadata["message"])
+        self.assertIn("gateway_element_id", e.condition_failure_metadata)
+        self.assertIn("evaluated_flows", e.condition_failure_metadata)
+        json.dumps(e.condition_failure_metadata)

--- a/agent_ui/agent_app/tests/test_issue7_product_bpmn_diagnostic.py
+++ b/agent_ui/agent_app/tests/test_issue7_product_bpmn_diagnostic.py
@@ -90,10 +90,14 @@ class Issue7ProductBpmnDiagnostic(TransactionTestCase):
 
     def _assert_no_issue9_gateway_failure(self, progress_data, error_message):
         error_text = str(error_message or "")
+        failure_reason = ""
         if isinstance(progress_data, dict):
+            failure_reason = str(progress_data.get("failure_reason", "") or "")
             failure_meta = progress_data.get("condition_failure_metadata") or {}
             if isinstance(failure_meta, dict):
                 error_text += " " + str(failure_meta.get("message", ""))
+                error_text += " " + str(failure_meta.get("gateway_element_id", ""))
+        self.assertNotEqual(failure_reason, "invalid_gateway")
         lowered = error_text.lower()
         self.assertNotIn("no matching condition and no default flow", lowered)
 

--- a/agent_ui/agent_app/tests/test_issue7_product_bpmn_diagnostic.py
+++ b/agent_ui/agent_app/tests/test_issue7_product_bpmn_diagnostic.py
@@ -7,9 +7,9 @@ hosted validation. They only exercise `execute_workflow_run` against the Django
 
 - **Completion checks:** `bi_weekly_report` and `property_due_diligence` must end
   `completed` for the test to pass (local test-DB only).
-- **Observability checks:** `bidder_onboarding` and `dap_report` only assert a
-  terminal outcome and run-detail HTML markers; failures/timeouts are expected
-  until GitHub issue #9 (BPMN gateway) is fixed.
+- **Observability checks:** `bidder_onboarding` and `dap_report` still allow
+  non-completed terminal outcomes in local test DB, but must **not** fail with
+  the historical issue #9 gateway error ("no matching condition and no default flow").
 
 Skipped unless ``ISSUE7_PRODUCT_BPMN_DIAGNOSTIC=1`` (CI stays fast).
 
@@ -88,6 +88,15 @@ class Issue7ProductBpmnDiagnostic(TransactionTestCase):
             msg="run detail should include BPMN diagram or operator panel markers",
         )
 
+    def _assert_no_issue9_gateway_failure(self, progress_data, error_message):
+        error_text = str(error_message or "")
+        if isinstance(progress_data, dict):
+            failure_meta = progress_data.get("condition_failure_metadata") or {}
+            if isinstance(failure_meta, dict):
+                error_text += " " + str(failure_meta.get("message", ""))
+        lowered = error_text.lower()
+        self.assertNotIn("no matching condition and no default flow", lowered)
+
     def test_bi_weekly_report_completes_local_test_db(self):
         """Local test DB only: must reach completed (not a staging sign-off)."""
         rid, status, _pd, err = self._run_workflow(
@@ -117,8 +126,8 @@ class Issue7ProductBpmnDiagnostic(TransactionTestCase):
         self._assert_run_detail_contains_bpmn_ui(rid)
 
     def test_bidder_onboarding_bpmn_diagnostic_observability(self):
-        """Terminal outcome + run-detail only; known BPMN gateway gaps (issue #9)."""
-        rid, status, _pd, err = self._run_workflow(
+        """Terminal outcome + run-detail; must not hit historical issue #9 gateway failure."""
+        rid, status, pd, err = self._run_workflow(
             "bidder_onboarding",
             {
                 "bidder_name": "Issue7 Diagnostic User",
@@ -142,11 +151,12 @@ class Issue7ProductBpmnDiagnostic(TransactionTestCase):
             ),
             msg=f"unexpected non-terminal status={status!r} err={err!r}",
         )
+        self._assert_no_issue9_gateway_failure(pd, err)
         self._assert_run_detail_contains_bpmn_ui(rid)
 
     def test_dap_report_bpmn_diagnostic_observability(self):
-        """Terminal outcome + run-detail only; gateway defect (issue #9)."""
-        rid, status, _pd, err = self._run_workflow(
+        """Terminal outcome + run-detail; must not hit historical issue #9 gateway failure."""
+        rid, status, pd, err = self._run_workflow(
             "dap_report",
             {"report_date": "2025-06-01", "lookback_days": 7},
         )
@@ -161,4 +171,5 @@ class Issue7ProductBpmnDiagnostic(TransactionTestCase):
             ),
             msg=f"unexpected non-terminal status={status!r} err={err!r}",
         )
+        self._assert_no_issue9_gateway_failure(pd, err)
         self._assert_run_detail_contains_bpmn_ui(rid)

--- a/agent_ui/agent_app/tests/test_workflow_runner_integration.py
+++ b/agent_ui/agent_app/tests/test_workflow_runner_integration.py
@@ -55,28 +55,35 @@ class WorkflowRunnerIntegrationTests(TransactionTestCase):
         gateway_calls = []
         original_select = bpmn_engine.select_exclusive_flow
 
-        async def _validate_input(self, state):
-            return None
+        class _FakeCursor:
+            def __init__(self, rows):
+                self._rows = rows
 
-        async def _check_property_status(self, state):
-            state.property_active = True
-            state.property_details = {"is_active": True, "is_approved": True}
-            return None
+            def fetchall(self):
+                return self._rows
 
-        async def _check_sam_compliance(self, state):
-            state.sam_passed = False
-            return None
+        class _FakeConn:
+            def execute(self, _query, _params):
+                rows = [
+                    {
+                        "name": "Issue9 Regression Bidder",
+                        "classification": "Entity",
+                        "excluding_agency": "Test Agency",
+                        "exclusion_type": "Debarment",
+                        "active_date": "2025-01-01",
+                        "termination_date": "Indefinite",
+                        "record_status": "Active",
+                        "sam_number": "SAM-ISSUE9",
+                    }
+                ]
+                return _FakeCursor(rows)
 
-        async def _finalize_status(self, state):
-            state.approval_status = "denied"
-            state.is_eligible = False
-            state.requires_manual_review = False
-            state.compliance_summary = "Issue #9 regression path"
-            state.bid_limit = 0.0
-            return None
+        class _FakeSamDbContext:
+            def __enter__(self):
+                return _FakeConn()
 
-        async def _create_audit_log(self, state):
-            return None
+            def __exit__(self, exc_type, exc, tb):
+                return False
 
         def _spy_select(bpmn, gateway_element_id, state, bindings):
             target_id = original_select(bpmn, gateway_element_id, state, bindings)
@@ -109,26 +116,7 @@ class WorkflowRunnerIntegrationTests(TransactionTestCase):
 
         with (
             patch("agent_app.bpmn_engine.select_exclusive_flow", side_effect=_spy_select),
-            patch(
-                "workflows.bidder_onboarding.workflow.BidderOnboardingWorkflow.validate_input",
-                new=_validate_input,
-            ),
-            patch(
-                "workflows.bidder_onboarding.workflow.BidderOnboardingWorkflow.check_property_status",
-                new=_check_property_status,
-            ),
-            patch(
-                "workflows.bidder_onboarding.workflow.BidderOnboardingWorkflow.check_sam_compliance",
-                new=_check_sam_compliance,
-            ),
-            patch(
-                "workflows.bidder_onboarding.workflow.BidderOnboardingWorkflow.finalize_status",
-                new=_finalize_status,
-            ),
-            patch(
-                "workflows.bidder_onboarding.workflow.BidderOnboardingWorkflow.create_audit_log",
-                new=_create_audit_log,
-            ),
+            patch("workflows.bidder_onboarding.workflow.get_sam_db", return_value=_FakeSamDbContext()),
         ):
             asyncio.run(execute_workflow_run(rid, send_message=None))
 
@@ -149,20 +137,68 @@ class WorkflowRunnerIntegrationTests(TransactionTestCase):
         gateway_calls = []
         original_select = bpmn_engine.select_exclusive_flow
 
-        async def _retrieve_data(self, state):
-            state.dap_data = [{"portfolio_id": "P1"}]
-            return None
-
-        async def _create_time_series(self, state):
-            state.time_series_data = [{"date": "2025-06-01", "value": 1.0}]
-            state.trends = {"trend": "stable"}
-            return None
-
-        async def _create_analysis(self, state):
-            state.analysis_results = {"ok": True}
-            state.issues_found = []
-            state.has_issues = False
-            return None
+        class _FakeGresAgent:
+            async def process(self, query, _context):
+                q = str(query)
+                if "Retrieve Daily Activity Performance (DAP) data" in q:
+                    return {
+                        "status": "ok",
+                        "data": {
+                            "auctions_active": 1,
+                            "auctions_new": 0,
+                            "auctions_closed": 0,
+                            "total_bids": 2,
+                            "new_bidders": 1,
+                            "average_bid": 1000,
+                            "property_views": 10,
+                            "unique_visitors": 5,
+                            "total_revenue": 2000,
+                            "compliance_checks": 3,
+                            "compliance_failures": 0,
+                            "uptime": 99.9,
+                            "response_time": 120,
+                        },
+                    }
+                if "Retrieve daily metrics from" in q:
+                    return {
+                        "status": "ok",
+                        "data": {
+                            "time_series": [
+                                {
+                                    "date": "2025-05-30",
+                                    "metrics": {
+                                        "auctions": {"active": 1},
+                                        "bidding": {"total_bids": 1},
+                                        "revenue": {"total": 1000},
+                                        "compliance": {"checks_failed": 0},
+                                    },
+                                },
+                                {
+                                    "date": "2025-06-01",
+                                    "metrics": {
+                                        "auctions": {"active": 1},
+                                        "bidding": {"total_bids": 2},
+                                        "revenue": {"total": 2000},
+                                        "compliance": {"checks_failed": 0},
+                                    },
+                                },
+                            ]
+                        },
+                    }
+                # Analysis query
+                return {
+                    "status": "ok",
+                    "data": {
+                        "summary": "Stable performance",
+                        "score": 85,
+                        "highlights": ["No major issues"],
+                        "concerns": [],
+                        "anomalies": [],
+                        "recommendations": ["Continue monitoring"],
+                        "risk_level": "low",
+                        "detailed_analysis": "All key metrics are within expected bounds.",
+                    },
+                }
 
         def _spy_select(bpmn, gateway_element_id, state, bindings):
             target_id = original_select(bpmn, gateway_element_id, state, bindings)
@@ -186,15 +222,7 @@ class WorkflowRunnerIntegrationTests(TransactionTestCase):
 
         with (
             patch("agent_app.bpmn_engine.select_exclusive_flow", side_effect=_spy_select),
-            patch("workflows.dap_report.workflow.DAPReportWorkflow.retrieve_data", new=_retrieve_data),
-            patch(
-                "workflows.dap_report.workflow.DAPReportWorkflow.create_time_series",
-                new=_create_time_series,
-            ),
-            patch(
-                "workflows.dap_report.workflow.DAPReportWorkflow.create_analysis",
-                new=_create_analysis,
-            ),
+            patch("workflows.dap_report.workflow._get_agent", return_value=_FakeGresAgent()),
         ):
             asyncio.run(execute_workflow_run(rid, send_message=None))
 

--- a/agent_ui/agent_app/tests/test_workflow_runner_integration.py
+++ b/agent_ui/agent_app/tests/test_workflow_runner_integration.py
@@ -11,7 +11,7 @@ from django.test import TransactionTestCase
 from agent_app.bpmn_engine import BpmnEngineError, _get_bindings_and_bpmn, normalize_engine_state
 from agent_app.models import WorkflowRun
 from agent_app.task_service import TaskPendingError
-from agent_app.workflow_context import normalize_bindings
+from agent_app.workflow_context import get_workflow_context, normalize_bindings
 from agent_app.workflow_registry import workflow_registry
 from agent_app.workflow_runner import (
     _execution_abort_reason_sync,
@@ -32,6 +32,178 @@ class WorkflowRunnerIntegrationTests(TransactionTestCase):
     def setUpClass(cls):
         super().setUpClass()
         workflow_registry.reload()
+
+    def _create_workflow_run(self, workflow_id: str, input_data: dict):
+        rid = _run_id()
+        WorkflowRun.objects.create(
+            run_id=rid,
+            workflow_id=workflow_id,
+            workflow_name=workflow_id,
+            status=WorkflowRun.STATUS_PENDING,
+            user_id=9,
+            input_data=input_data,
+        )
+        return rid
+
+    def test_issue9_bidder_onboarding_routes_gateway_in_runner_path(self):
+        """Issue #9 regression: real runner path must pass Gateway_SAM_Decision."""
+        from agent_app import bpmn_engine
+
+        ctx = get_workflow_context("bidder_onboarding")
+        self.assertIn("/currentVersion/", ctx.get("files", {}).get("bpmn_path", ""))
+
+        gateway_calls = []
+        original_select = bpmn_engine.select_exclusive_flow
+
+        async def _validate_input(self, state):
+            return None
+
+        async def _check_property_status(self, state):
+            state.property_active = True
+            state.property_details = {"is_active": True, "is_approved": True}
+            return None
+
+        async def _check_sam_compliance(self, state):
+            state.sam_passed = False
+            return None
+
+        async def _finalize_status(self, state):
+            state.approval_status = "denied"
+            state.is_eligible = False
+            state.requires_manual_review = False
+            state.compliance_summary = "Issue #9 regression path"
+            state.bid_limit = 0.0
+            return None
+
+        async def _create_audit_log(self, state):
+            return None
+
+        def _spy_select(bpmn, gateway_element_id, state, bindings):
+            target_id = original_select(bpmn, gateway_element_id, state, bindings)
+            if gateway_element_id == "Gateway_SAM_Decision":
+                gateway_calls.append(
+                    {
+                        "gateway": gateway_element_id,
+                        "sam_passed": getattr(state, "sam_passed", None),
+                        "default_flow_id": (bpmn.get("elements", {}).get(gateway_element_id) or {}).get(
+                            "default_flow_id"
+                        ),
+                        "target_id": target_id,
+                    }
+                )
+            return target_id
+
+        rid = self._create_workflow_run(
+            "bidder_onboarding",
+            {
+                "bidder_name": "Issue9 Regression Bidder",
+                "property_id": 1,
+                "registration_data": {
+                    "email": "issue9@example.invalid",
+                    "phone": "555-0100",
+                    "terms_accepted": True,
+                    "age_accepted": True,
+                },
+            },
+        )
+
+        with (
+            patch("agent_app.bpmn_engine.select_exclusive_flow", side_effect=_spy_select),
+            patch(
+                "workflows.bidder_onboarding.workflow.BidderOnboardingWorkflow.validate_input",
+                new=_validate_input,
+            ),
+            patch(
+                "workflows.bidder_onboarding.workflow.BidderOnboardingWorkflow.check_property_status",
+                new=_check_property_status,
+            ),
+            patch(
+                "workflows.bidder_onboarding.workflow.BidderOnboardingWorkflow.check_sam_compliance",
+                new=_check_sam_compliance,
+            ),
+            patch(
+                "workflows.bidder_onboarding.workflow.BidderOnboardingWorkflow.finalize_status",
+                new=_finalize_status,
+            ),
+            patch(
+                "workflows.bidder_onboarding.workflow.BidderOnboardingWorkflow.create_audit_log",
+                new=_create_audit_log,
+            ),
+        ):
+            asyncio.run(execute_workflow_run(rid, send_message=None))
+
+        run = WorkflowRun.objects.get(run_id=rid)
+        self.assertEqual(run.status, WorkflowRun.STATUS_COMPLETED)
+        self.assertTrue(gateway_calls, msg="expected Gateway_SAM_Decision to be evaluated")
+        self.assertEqual(gateway_calls[0]["sam_passed"], False)
+        self.assertEqual(gateway_calls[0]["default_flow_id"], "Flow_gateway_no")
+        self.assertEqual(gateway_calls[0]["target_id"], "finalize_status")
+
+    def test_issue9_dap_report_routes_gateway_in_runner_path(self):
+        """Issue #9 regression: real runner path must pass Gateway_1."""
+        from agent_app import bpmn_engine
+
+        ctx = get_workflow_context("dap_report")
+        self.assertIn("/currentVersion/", ctx.get("files", {}).get("bpmn_path", ""))
+
+        gateway_calls = []
+        original_select = bpmn_engine.select_exclusive_flow
+
+        async def _retrieve_data(self, state):
+            state.dap_data = [{"portfolio_id": "P1"}]
+            return None
+
+        async def _create_time_series(self, state):
+            state.time_series_data = [{"date": "2025-06-01", "value": 1.0}]
+            state.trends = {"trend": "stable"}
+            return None
+
+        async def _create_analysis(self, state):
+            state.analysis_results = {"ok": True}
+            state.issues_found = []
+            state.has_issues = False
+            return None
+
+        def _spy_select(bpmn, gateway_element_id, state, bindings):
+            target_id = original_select(bpmn, gateway_element_id, state, bindings)
+            if gateway_element_id == "Gateway_1":
+                gateway_calls.append(
+                    {
+                        "gateway": gateway_element_id,
+                        "has_issues": getattr(state, "has_issues", None),
+                        "default_flow_id": (bpmn.get("elements", {}).get(gateway_element_id) or {}).get(
+                            "default_flow_id"
+                        ),
+                        "target_id": target_id,
+                    }
+                )
+            return target_id
+
+        rid = self._create_workflow_run(
+            "dap_report",
+            {"report_date": "2025-06-01", "lookback_days": 7},
+        )
+
+        with (
+            patch("agent_app.bpmn_engine.select_exclusive_flow", side_effect=_spy_select),
+            patch("workflows.dap_report.workflow.DAPReportWorkflow.retrieve_data", new=_retrieve_data),
+            patch(
+                "workflows.dap_report.workflow.DAPReportWorkflow.create_time_series",
+                new=_create_time_series,
+            ),
+            patch(
+                "workflows.dap_report.workflow.DAPReportWorkflow.create_analysis",
+                new=_create_analysis,
+            ),
+        ):
+            asyncio.run(execute_workflow_run(rid, send_message=None))
+
+        run = WorkflowRun.objects.get(run_id=rid)
+        self.assertEqual(run.status, WorkflowRun.STATUS_COMPLETED)
+        self.assertTrue(gateway_calls, msg="expected Gateway_1 to be evaluated")
+        self.assertEqual(gateway_calls[0]["has_issues"], False)
+        self.assertEqual(gateway_calls[0]["default_flow_id"], "Flow_6")
+        self.assertEqual(gateway_calls[0]["target_id"], "Gateway_2")
 
     def test_par015_message_catch_execute_then_resume(self):
         workflow_registry.reload()

--- a/docs/operations/BPMN_STAGING_VALIDATION.md
+++ b/docs/operations/BPMN_STAGING_VALIDATION.md
@@ -45,7 +45,9 @@ cd agent_ui && ../venv/bin/python manage.py test agent_app.tests.test_workflow_r
 Opt-in module: **`test_issue7_product_bpmn_diagnostic`**. **Not** staging sign-off.
 
 - **`bi_weekly_report`** and **`property_due_diligence`:** tests **require** `completed` on the test DB (sanity for those two flows locally).
-- **`bidder_onboarding`** and **`dap_report`:** **observability only** — terminal status may be `failed` (known BPMN gateway issues; [issue #9](https://github.com/cappelaere/beeai/issues/9)).
+- **`bidder_onboarding`** and **`dap_report`:** observability-focused, but now
+  with an explicit guard: runs must **not** fail with the historical issue #9
+  gateway error (`no matching condition and no default flow`).
 
 ```bash
 cd agent_ui && ISSUE7_PRODUCT_BPMN_DIAGNOSTIC=1 ../venv/bin/python manage.py test \
@@ -163,7 +165,7 @@ Product workflows in the local pass did not reach **waiting_for_task** for manua
 
 | Issue | Summary |
 |-------|---------|
-| [#9](https://github.com/cappelaere/beeai/issues/9) | **`bidder_onboarding` / `dap_report`:** Exclusive gateways **`Gateway_SAM_Decision`** and **`Gateway_1`** — no matching condition / default after handler transitions (example run IDs `494034f4`, `121edda3` on test DB). |
+| [#9](https://github.com/cappelaere/beeai/issues/9) | Added runner-path regressions for **`bidder_onboarding`** and **`dap_report`** that verify execution reaches and routes through **`Gateway_SAM_Decision`** / **`Gateway_1`** with active `currentVersion` BPMN assets; diagnostic tests now assert the historical no-match/no-default gateway error does not recur. |
 | **Branch fix (import)** | **`dap_report`:** load `agent_runner` via `importlib` from repo-relative path so `import agent_ui.agent_runner` is not shadowed when `sys.path` includes `agent_ui/` (`workflows/dap_report/workflow.py`). |
 
 ---


### PR DESCRIPTION
## Summary
- preserve structured exclusive-gateway failure metadata so runner-path failures include gateway id, default flow id, and evaluated flows
- add full `execute_workflow_run` regressions for `bidder_onboarding` and `dap_report` proving runtime routing through `Gateway_SAM_Decision` and `Gateway_1`
- tighten Issue #7 diagnostic/docs expectations to explicitly guard against the historical no-match/no-default gateway failure text

## Test plan
- [x] `venv/bin/python agent_ui/manage.py test agent_app.tests.test_workflow_runner_integration.WorkflowRunnerIntegrationTests.test_issue9_bidder_onboarding_routes_gateway_in_runner_path agent_app.tests.test_workflow_runner_integration.WorkflowRunnerIntegrationTests.test_issue9_dap_report_routes_gateway_in_runner_path agent_app.tests.test_bpmn_gateway_conditions --settings=agent_ui.settings -v 1`
- [x] `ISSUE7_PRODUCT_BPMN_DIAGNOSTIC=1 venv/bin/python agent_ui/manage.py test agent_app.tests.test_issue7_product_bpmn_diagnostic.Issue7ProductBpmnDiagnostic.test_bidder_onboarding_bpmn_diagnostic_observability agent_app.tests.test_issue7_product_bpmn_diagnostic.Issue7ProductBpmnDiagnostic.test_dap_report_bpmn_diagnostic_observability --settings=agent_ui.settings -v 2`

Closes #9.

Made with [Cursor](https://cursor.com)