### PR TITLE
style(tests): normalize formatting in API and runner integration tests

### DIFF
--- a/agent_ui/agent_app/tests/test_api.py
+++ b/agent_ui/agent_app/tests/test_api.py
@@ -63,10 +63,7 @@ class ChatAPITests(TestCase):
             if response.status_code == 200 and "session_id" in data:
                 session_id = data["session_id"]
                 break
-            if (
-                "database table is locked" in json.dumps(data).lower()
-                and attempt == 0
-            ):
+            if "database table is locked" in json.dumps(data).lower() and attempt == 0:
                 time.sleep(0.1)
                 continue
             self.fail(f"Failed to create chat session: status={response.status_code}, body={data}")

--- a/agent_ui/agent_app/tests/test_workflow_runner_integration.py
+++ b/agent_ui/agent_app/tests/test_workflow_runner_integration.py
@@ -92,9 +92,9 @@ class WorkflowRunnerIntegrationTests(TransactionTestCase):
                     {
                         "gateway": gateway_element_id,
                         "sam_passed": getattr(state, "sam_passed", None),
-                        "default_flow_id": (bpmn.get("elements", {}).get(gateway_element_id) or {}).get(
-                            "default_flow_id"
-                        ),
+                        "default_flow_id": (
+                            bpmn.get("elements", {}).get(gateway_element_id) or {}
+                        ).get("default_flow_id"),
                         "target_id": target_id,
                     }
                 )
@@ -116,7 +116,9 @@ class WorkflowRunnerIntegrationTests(TransactionTestCase):
 
         with (
             patch("agent_app.bpmn_engine.select_exclusive_flow", side_effect=_spy_select),
-            patch("workflows.bidder_onboarding.workflow.get_sam_db", return_value=_FakeSamDbContext()),
+            patch(
+                "workflows.bidder_onboarding.workflow.get_sam_db", return_value=_FakeSamDbContext()
+            ),
         ):
             asyncio.run(execute_workflow_run(rid, send_message=None))
 
@@ -207,9 +209,9 @@ class WorkflowRunnerIntegrationTests(TransactionTestCase):
                     {
                         "gateway": gateway_element_id,
                         "has_issues": getattr(state, "has_issues", None),
-                        "default_flow_id": (bpmn.get("elements", {}).get(gateway_element_id) or {}).get(
-                            "default_flow_id"
-                        ),
+                        "default_flow_id": (
+                            bpmn.get("elements", {}).get(gateway_element_id) or {}
+                        ).get("default_flow_id"),
                         "target_id": target_id,
                     }
                 )


### PR DESCRIPTION
## Linked issue
- Relates to #14

## Approved Plan
This follow-up is intentionally scoped to formatting-only updates requested during post-merge cleanup for the #14 line of work:
1. Keep behavior unchanged.
2. Normalize wrapping/formatting in the two remaining modified test files.
3. Re-run lint checks and report quality status in the PR.

## Scope boundary
- No production/runtime code changes.
- No workflow logic changes.
- Only test-file formatting normalization.

## Summary
- normalize multiline formatting in `agent_ui/agent_app/tests/test_api.py`
- normalize wrapping in gateway assertion/patch blocks in `agent_ui/agent_app/tests/test_workflow_runner_integration.py`
- keep behavior unchanged while aligning with lint/format expectations

## Test plan
- [x] `ruff check --select B010,C901`
- [ ] `make quality`